### PR TITLE
fix build error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,19 +116,19 @@ AC_ARG_ENABLE([upnp-default],
   [use_upnp_default=no])
 
 AC_ARG_ENABLE(tests,
-    AS_HELP_STRING([--disable-tests],[do not compile tests (default is to compile)]),
+    AS_HELP_STRING([--enable-tests],[do compile tests (default is not to compile)]),
     [use_tests=$enableval],
-    [use_tests=yes])
+    [use_tests=no])
 
 AC_ARG_ENABLE(gui-tests,
-    AS_HELP_STRING([--disable-gui-tests],[do not compile GUI tests (default is to compile if GUI and tests enabled)]),
+    AS_HELP_STRING([--enable-gui-tests],[do compile GUI tests (default is not to compile)]),
     [use_gui_tests=$enableval],
     [use_gui_tests=$use_tests])
 
 AC_ARG_ENABLE(bench,
-    AS_HELP_STRING([--disable-bench],[do not compile benchmarks (default is to compile)]),
+    AS_HELP_STRING([--enable-bench],[do compile benchmarks (default is not to compile)]),
     [use_bench=$enableval],
-    [use_bench=yes])
+    [use_bench=no])
 
 AC_ARG_ENABLE([extended-functional-tests],
     AS_HELP_STRING([--enable-extended-functional-tests],[enable expensive functional tests when using lcov (default no)]),

--- a/configure.ac
+++ b/configure.ac
@@ -235,6 +235,8 @@ if test "x$enable_debug" = xyes; then
     fi
 fi
 
+CFLAGS="$CFLAGS -fPIC"
+
 ERROR_CXXFLAGS=
 if test "x$enable_werror" = "xyes"; then
   if test "x$CXXFLAG_WERROR" = "x"; then


### PR DESCRIPTION
ビルド時にエラーが吐かれ、正常にビルドできない問題を修正しました。
なお、これによりコンパイル時にtests、gui-tests、benchがビルドされなくなります。
なお、benchに関しては問題ありませんでしたが、ビルド時間短縮のため除外しました。tests、gui-testsのビルドを行うには修正が必要です。